### PR TITLE
Catch errors in all element selectors

### DIFF
--- a/deletefb/deletefb.py
+++ b/deletefb/deletefb.py
@@ -103,27 +103,30 @@ def delete_posts(user_email_address,
     driver.get(user_profile_url)
 
     for _ in range(MAX_POSTS):
-        post_button_sel = "_4xev"
-        timeline_element = driver.find_element_by_class_name(post_button_sel)
-        actions = ActionChains(driver)
-        actions.move_to_element(timeline_element).click().perform()
-
-        menu = driver.find_element_by_css_selector("#globalContainer > div.uiContextualLayerPositioner.uiLayer > div")
-        actions.move_to_element(menu).perform()
-
         try:
-            delete_button = menu.find_element_by_xpath("//a[@data-feed-option-name=\"FeedDeleteOption\"]")
+            post_button_sel = "_4xev"
+            timeline_element = driver.find_element_by_class_name(post_button_sel)
+            actions = ActionChains(driver)
+            actions.move_to_element(timeline_element).click().perform()
 
-        # FIXME Using a bare except here to avoid having to handle all possible exceptions
+            menu = driver.find_element_by_css_selector("#globalContainer > div.uiContextualLayerPositioner.uiLayer > div")
+            actions.move_to_element(menu).perform()
+
+            try:
+                delete_button = menu.find_element_by_xpath("//a[@data-feed-option-name=\"FeedDeleteOption\"]")
+
+            # FIXME Using a bare except here to avoid having to handle all possible exceptions
+            except:
+                delete_button = menu.find_element_by_xpath("//a[@data-feed-option-name=\"HIDE_FROM_TIMELINE\"]")
+
+            actions.move_to_element(delete_button).click().perform()
+
+            confirmation_button = driver.find_element_by_class_name("layerConfirm")
+
+            # Facebook would not let me get focus on this button without some custom JS
+            driver.execute_script("arguments[0].click();", confirmation_button)
         except:
-            delete_button = menu.find_element_by_xpath("//a[@data-feed-option-name=\"HIDE_FROM_TIMELINE\"]")
-
-        actions.move_to_element(delete_button).click().perform()
-
-        confirmation_button = driver.find_element_by_class_name("layerConfirm")
-
-        # Facebook would not let me get focus on this button without some custom JS
-        driver.execute_script("arguments[0].click();", confirmation_button)
+            pass
 
         # Required to sleep the thread for a bit after using JS to click this button
         time.sleep(5)

--- a/deletefb/deletefb.py
+++ b/deletefb/deletefb.py
@@ -9,6 +9,7 @@ from selenium.webdriver.chrome.options import Options
 from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException
 
 MAX_POSTS = 5000
+SELENIUM_EXCEPTIONS = (NoSuchElementException, StaleElementReferenceException)
 
 def run_delete():
     parser = argparse.ArgumentParser()
@@ -116,7 +117,7 @@ def delete_posts(user_email_address,
 
                 try:
                     delete_button = menu.find_element_by_xpath("//a[@data-feed-option-name=\"FeedDeleteOption\"]")
-                except (NoSuchElementException, StaleElementReferenceException):
+                except SELENIUM_EXCEPTIONS:
                     delete_button = menu.find_element_by_xpath("//a[@data-feed-option-name=\"HIDE_FROM_TIMELINE\"]")
 
                 actions.move_to_element(delete_button).click().perform()
@@ -124,7 +125,7 @@ def delete_posts(user_email_address,
 
                 # Facebook would not let me get focus on this button without some custom JS
                 driver.execute_script("arguments[0].click();", confirmation_button)
-            except (NoSuchElementException, StaleElementReferenceException):
+            except SELENIUM_EXCEPTIONS:
                 continue
             else:
                 break

--- a/deletefb/deletefb.py
+++ b/deletefb/deletefb.py
@@ -6,7 +6,7 @@ import time
 from seleniumrequests import Chrome
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.chrome.options import Options
-
+from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException
 
 MAX_POSTS = 5000
 
@@ -103,30 +103,31 @@ def delete_posts(user_email_address,
     driver.get(user_profile_url)
 
     for _ in range(MAX_POSTS):
-        try:
-            post_button_sel = "_4xev"
-            timeline_element = driver.find_element_by_class_name(post_button_sel)
-            actions = ActionChains(driver)
-            actions.move_to_element(timeline_element).click().perform()
+        post_button_sel = "_4xev"
 
-            menu = driver.find_element_by_css_selector("#globalContainer > div.uiContextualLayerPositioner.uiLayer > div")
-            actions.move_to_element(menu).perform()
-
+        while True:
             try:
-                delete_button = menu.find_element_by_xpath("//a[@data-feed-option-name=\"FeedDeleteOption\"]")
+                timeline_element = driver.find_element_by_class_name(post_button_sel)
+                actions = ActionChains(driver)
+                actions.move_to_element(timeline_element).click().perform()
 
-            # FIXME Using a bare except here to avoid having to handle all possible exceptions
-            except:
-                delete_button = menu.find_element_by_xpath("//a[@data-feed-option-name=\"HIDE_FROM_TIMELINE\"]")
+                menu = driver.find_element_by_css_selector("#globalContainer > div.uiContextualLayerPositioner.uiLayer > div")
+                actions.move_to_element(menu).perform()
 
-            actions.move_to_element(delete_button).click().perform()
+                try:
+                    delete_button = menu.find_element_by_xpath("//a[@data-feed-option-name=\"FeedDeleteOption\"]")
+                except (NoSuchElementException, StaleElementReferenceException):
+                    delete_button = menu.find_element_by_xpath("//a[@data-feed-option-name=\"HIDE_FROM_TIMELINE\"]")
 
-            confirmation_button = driver.find_element_by_class_name("layerConfirm")
+                actions.move_to_element(delete_button).click().perform()
+                confirmation_button = driver.find_element_by_class_name("layerConfirm")
 
-            # Facebook would not let me get focus on this button without some custom JS
-            driver.execute_script("arguments[0].click();", confirmation_button)
-        except:
-            pass
+                # Facebook would not let me get focus on this button without some custom JS
+                driver.execute_script("arguments[0].click();", confirmation_button)
+            except (NoSuchElementException, StaleElementReferenceException):
+                continue
+            else:
+                break
 
         # Required to sleep the thread for a bit after using JS to click this button
         time.sleep(5)


### PR DESCRIPTION
First of, thanks for the package! I've been planning to write something like this, but never got around doing it.

This PR wraps lines 89-90 in a `try..except` statement:

https://github.com/weskerfoot/DeleteFB/blob/56c8a22816d704c02ff718cd1f835b1316ce373e/deletefb/deletefb.py#L89-L90

Without the `try..except` statement, I was getting the following error:

```
Traceback (most recent call last):
  File "/Users/mimischi/anaconda3/envs/deletefb/bin/deletefb", line 11, in <module>
    load_entry_point('delete-facebook-posts', 'console_scripts', 'deletefb')()
  File "/Users/mimischi/Code/fb/DeleteFB/deletefb/deletefb.py", line 34, in run_delete
    user_profile_url=args.profile_url)
  File "/Users/mimischi/Code/fb/DeleteFB/deletefb/deletefb.py", line 89, in delete_posts
    menu = driver.find_element_by_css_selector("#globalContainer > div.uiContextualLayerPositioner.uiLayer > div")
  File "/Users/mimischi/anaconda3/envs/deletefb/lib/python3.7/site-packages/selenium/webdriver/remote/webdriver.py", line 598, in find_element_by_css_selector
    return self.find_element(by=By.CSS_SELECTOR, value=css_selector)
  File "/Users/mimischi/anaconda3/envs/deletefb/lib/python3.7/site-packages/selenium/webdriver/remote/webdriver.py", line 978, in find_element
    'value': value})['value']
  File "/Users/mimischi/anaconda3/envs/deletefb/lib/python3.7/site-packages/selenium/webdriver/remote/webdriver.py", line 321, in execute
    self.error_handler.check_response(response)
  File "/Users/mimischi/anaconda3/envs/deletefb/lib/python3.7/site-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.NoSuchElementException: Message: no such element: Unable to locate element: {"method":"css selector","selector":"#globalContainer > div.uiContextualLayerPositioner.uiLayer > div"}
  (Session info: chrome=74.0.3729.157)
  (Driver info: chromedriver=74.0.3729.6 (255758eccf3d244491b8a1317aa76e1ce10d57e9-refs/branch-heads/3729@{#29}),platform=Mac OS X 10.14.4 x86_64)
```