### PR TITLE
Add option for headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Personally, I did this so I would feel less attached to my Facebook profile
 
 ## How To Use
 
-* Make sure that you have Google Chrome installed and that it is up to date, as
-  well as the chromedriver for Selenium. See [here](https://sites.google.com/a/chromium.org/chromedriver/downloads). On Arch Linux you can find this in the `chromium` package, but it will vary by OS.
+* Make sure that you have Google Chrome installed and that it is up to date
+* Also install the chromedriver for Selenium. See [here](https://sites.google.com/a/chromium.org/chromedriver/downloads). On Arch Linux you can find this in the `chromium` package, and on Ubuntu it is `chromium-chromedriver`.
 * `pip3 install --user delete-facebook-posts`
 * `deletefb -E "youremail@example.org" -P "yourfacebookpassword" -U "https://www.facebook.com/your.profile.url"`
 * The script will log into your Facebook account, go to your profile page, and

--- a/deletefb/deletefb.py
+++ b/deletefb/deletefb.py
@@ -10,32 +10,55 @@ MAX_POSTS = 5000
 
 def run_delete():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-E",
-                        "--email",
-                        default=None,
-                        help="Your email address associated with the account")
+    parser.add_argument(
+        "-E",
+        "--email",
+        required=True,
+        dest="email",
+        type=str,
+        help="Your email address associated with the account"
+    )
 
-    parser.add_argument("-P",
-                        "--password",
-                        default=None,
-                        help="Your Facebook password")
+    parser.add_argument(
+        "-P",
+        "--password",
+        required=True,
+        dest="password",
+        type=str,
+        help="Your Facebook password"
+    )
 
-    parser.add_argument("-U",
-                        "--profile-url",
-                        default=None,
-                        help="""
-                        The link to your Facebook profile, e.g. https://www.facebook.com/your.name
-                        """)
+    parser.add_argument(
+        "-U",
+        "--profile-url",
+        required=True,
+        dest="profile_url",
+        type=str,
+        help="The link to your Facebook profile, e.g. https://www.facebook.com/your.name"
+    )
+
+    parser.add_argument(
+        "-H",
+        "--headless",
+        action="store_true",
+        dest="is_headless",
+        default=False,
+        help="Run browser in headless mode (no gui)"
+    )
 
     args = parser.parse_args()
 
-    delete_posts(user_email_address=args.email,
-                 user_password=args.password,
-                 user_profile_url=args.profile_url)
+    delete_posts(
+        user_email_address=args.email,
+        user_password=args.password,
+        user_profile_url=args.profile_url,
+        is_headless=args.is_headless
+    )
 
-def delete_posts(user_email_address=None,
-                 user_password=None,
-                 user_profile_url=None):
+def delete_posts(user_email_address,
+                 user_password,
+                 user_profile_url,
+                 is_headless):
     """
     user_email_address: Your Email
     user_password: Your password
@@ -50,10 +73,15 @@ def delete_posts(user_email_address=None,
     chrome_options = Options()
     prefs = {"profile.default_content_setting_values.notifications" : 2}
     chrome_options.add_experimental_option("prefs", prefs)
-
     chrome_options.add_argument("start-maximized")
 
-    driver = Chrome(chrome_options=chrome_options)
+    if is_headless:
+        chrome_options.add_argument('--headless')
+        chrome_options.add_argument('--disable-gpu')
+        chrome_options.add_argument('--no-sandbox')
+        chrome_options.add_argument('log-level=2')
+
+    driver = Chrome(options=chrome_options)
     driver.implicitly_wait(10)
 
     driver.get("https://facebook.com")

--- a/deletefb/deletefb.py
+++ b/deletefb/deletefb.py
@@ -78,7 +78,6 @@ def delete_posts(user_email_address,
     if is_headless:
         chrome_options.add_argument('--headless')
         chrome_options.add_argument('--disable-gpu')
-        chrome_options.add_argument('--no-sandbox')
         chrome_options.add_argument('log-level=2')
 
     driver = Chrome(options=chrome_options)


### PR DESCRIPTION
Resolves https://github.com/weskerfoot/DeleteFB/issues/5 by adding the `--headless`, `--disable-gpu`, and `log-level=2` flags which allow for Chromium to be run in headless mode.