### PR TITLE
Add 'attr' as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ selenium-requests==1.3
 six==1.12.0
 tldextract==2.2.0
 urllib3==1.25.2
+attr


### PR DESCRIPTION
Add 'attr' as requirement to avoid "ModuleNotFoundError: No module named 'attr'" error message.