### PR TITLE
Fix login

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ git+https://github.com/weskerfoot/DeleteFB.git`
 * Be patient as it will take a very long time, but it will eventually clear
   everything. You may safely minimize the chrome window without breaking it.
 
+## Login
+* The tool will log in using the credentials passed to it. It will wait until
+  the page "https://www.facebook.com/" is loaded in order to avoid any issues
+  with logging in. If you pass a 2FA token explicitly with the `-F` option,
+  then it will try to enter that for you. If there are any issues, it simply
+  pauses indefinitely to allow the user to resolve the problems, and then
+  continues execution.
+
 ## 2FA
 * It is recommended that you disable Two-Factor Authentication temporarily
   while you are running the script, in order to get the best experience.

--- a/deletefb/tools/login.py
+++ b/deletefb/tools/login.py
@@ -45,7 +45,7 @@ def login(user_email_address,
 
     driver.implicitly_wait(10)
 
-    driver.get("https://facebook.com")
+    driver.get("https://www.facebook.com/login/device-based/regular/login/?login_attempt=1&lwv=110")
 
     email = "email"
     password = "pass"
@@ -96,5 +96,11 @@ def login(user_email_address,
         print("Continuing execution")
     else:
         pass
+
+    # block until we have reached the main page
+    # print a message warning the user
+    while driver.current_url != "https://www.facebook.com/":
+        print("Execution blocked: Please navigate to https://www.facebook.com to continue")
+        time.sleep(5)
 
     return driver


### PR DESCRIPTION
Addresses:
- https://github.com/weskerfoot/DeleteFB/issues/66
- https://github.com/weskerfoot/DeleteFB/issues/38

The script will use the URL `https://www.facebook.com/login/device-based/regular/login/?login_attempt=1&lwv=110` to log in now.

If it detects that it still hasn't loaded the main page (i.e. `https://www.facebook.com`) after trying to log in and enter 2FA, then it will poll the current URL and print a message to the console until the user resolves it manually. Then it will continue execution.

This should hopefully be a bit more fault tolerant and allow users to manually resolve weird edge cases.

I've tested it with 2FA enabled, and with the "Save Browser" page coming up, and it worked fine in both cases.