### PR TITLE
Fixes #75

### DIFF
--- a/deletefb/tools/archive.py
+++ b/deletefb/tools/archive.py
@@ -38,7 +38,7 @@ class Archive:
 def archiver(archive_type):
 
     archive_file = open(
-        (Path(".") / Path(archive_type).name).with_suffix(".log"),
+        str((Path(".") / Path(archive_type).name).with_suffix(".log")),
         mode="ta",
         buffering=1
     )


### PR DESCRIPTION
Python versions less than 3.6 do not support passing a Path object directly to `open()` so it must be converted to a string first.