### PR TITLE
add option to pass path to chrome binary

### DIFF
--- a/deletefb/deletefb.py
+++ b/deletefb/deletefb.py
@@ -89,6 +89,16 @@ def run_delete():
         help="The year(s) you want posts deleted."
     )
 
+    parser.add_argument(
+        "-B",
+        "--chromebin",
+        required=False,
+        default=False,
+        dest="chromebin",
+        type=str,
+        help="Optional path to the Google Chrome (or Chromium) binary"
+    )
+
     args = parser.parse_args()
 
     settings["ARCHIVE"] = not args.archive_off
@@ -102,7 +112,8 @@ def run_delete():
         user_email_address=args.email,
         user_password=args_user_password,
         is_headless=args.is_headless,
-        two_factor_token=args.two_factor_token
+        two_factor_token=args.two_factor_token,
+        chrome_binary_path=args.chromebin
     )
 
     if args.mode == "wall":

--- a/deletefb/tools/chrome_driver.py
+++ b/deletefb/tools/chrome_driver.py
@@ -51,7 +51,6 @@ def setup_selenium(driver_path, options):
     # Configures selenium to use a custom path
     return webdriver.Chrome(executable_path=driver_path, options=options)
 
-
 def get_webdriver():
     """
      Ensure a webdriver is available

--- a/deletefb/tools/login.py
+++ b/deletefb/tools/login.py
@@ -5,11 +5,11 @@ import time
 
 from .chrome_driver import get_webdriver, setup_selenium
 
-
 def login(user_email_address,
           user_password,
           is_headless,
-          two_factor_token):
+          two_factor_token,
+          chrome_binary_path=None):
     """
     Attempts to log into Facebook
     Returns a driver object
@@ -27,6 +27,10 @@ def login(user_email_address,
     chrome_options = Options()
     prefs = {"profile.default_content_setting_values.notifications": 2, 'disk-cache-size': 4096}
     chrome_options.add_experimental_option("prefs", prefs)
+
+    if chrome_binary_path:
+        chrome_options.binary_location = chrome_binary_path
+
     chrome_options.add_argument("start-maximized")
 
     if is_headless:


### PR DESCRIPTION
Fixes https://github.com/weskerfoot/DeleteFB/issues/99

Reported initially by https://github.com/weskerfoot/DeleteFB/issues/95#issuecomment-569897059

New feature that allows you to pass `-B /path/to/google-chrome`

E.g. `/usr/bin/google-chrome-stable` on my machine.