### PR TITLE
WebDriverException not defined

### DIFF
--- a/deletefb/tools/chrome_driver.py
+++ b/deletefb/tools/chrome_driver.py
@@ -2,6 +2,7 @@ from ..exceptions import UnknownOSException, ChromeError
 from .common import NO_CHROME_DRIVER
 from clint.textui import puts, colored
 from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
 from shutil import which
 from subprocess import check_output
 from urllib.request import urlretrieve


### PR DESCRIPTION
I didn't have chromedriver installed initially - it caused a secondary exception. 

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/tcrha/.local/bin/deletefb", line 8, in <module>
    sys.exit(run_delete())
  File "/home/tcrha/.local/lib/python3.8/site-packages/deletefb/deletefb.py", line 112, in run_delete
    driver = login(
  File "/home/tcrha/.local/lib/python3.8/site-packages/deletefb/tools/login.py", line 44, in login
    driver = setup_selenium(chrome_options, chrome_binary_path)
  File "/home/tcrha/.local/lib/python3.8/site-packages/deletefb/tools/chrome_driver.py", line 66, in setup_selenium
    except WebDriverException:
NameError: name 'WebDriverException' is not defined
```